### PR TITLE
plot_hline() made. makefile has clean function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "files.associations": {
-        "TST_RAST.C": "cpp"
+        "TST_RAST.C": "cpp",
+        "ANIMATE.C": "cpp"
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,5 @@ tst_rast.o: tst_rast.c raster.h
 	$(CC) -c tst_rast.c -o tst_rast.o
 
 clean:
-	$(RM) *.o
+	$(RM) $(OBJ) $(EXEC)
+	

--- a/TST_RAST.C
+++ b/TST_RAST.C
@@ -1,14 +1,33 @@
 #include "raster.h"
 #include "bitmaps.h"
-#include <osbind.h>
+#include <stdio.h>
+#include <osbind.h> 
+#include <linea.h>
+
+#define XOR 2
+#define AND 3
 
 int main(){
 	int i;
+	int y;
 
 	void *base = Physbase();
+	linea0();
 
 	clear_screen((UINT16 *)base, 0);
-    
+
+	while (!Cconis()){
+		plot_hline(y, XOR);
+		Vsync();
+		plot_hline(y,XOR);
+
+		y++;
+
+		if (y == 400)
+			y = 0;
+	}
+	
+	
 	for (i = 0; i < 25; i++){
 		/*plot_bitmap_16(base, 480, 16 * i, dino_wup_bitmap, HEIGHT_32);*/
 		plot_bitmap_32((UINT32 *)base, 160, 32 * i, dino_wup_bitmap, HEIGHT_32);

--- a/bitmaps.h
+++ b/bitmaps.h
@@ -17,4 +17,4 @@ extern const UINT32 seven_bitmap[HEIGHT_32];
 extern const UINT32 eight_bitmap[HEIGHT_32];
 extern const UINT32 nine_bitmap[HEIGHT_32];
 
-#endif // BITMAPS_H
+#endif

--- a/raster.c
+++ b/raster.c
@@ -1,4 +1,7 @@
 #include "raster.h"
+#include <stdio.h>
+#include <osbind.h> 
+#include <linea.h>
 
 void plot_bitmap_32(UINT32 *base, int x, int y, const UINT32 *bitmap, unsigned int height){
 	int i;
@@ -33,3 +36,24 @@ void clear_screen(UINT16 *base, int pattern){
 		}
 }
 
+/*
+	MODES:
+		- 0: replace
+		- 1: or
+		- 2: xor
+		- 3: and
+	SUMMARY:
+		Plots a horizontal line at a specified y coordinate. 
+		linea0() must be called before this function.
+*/
+void plot_hline(unsigned short y, short mode)
+{
+	X1 = (unsigned short) 0;
+	Y1 = y;
+	X2 = (unsigned short) 639;
+	Y2 = y;
+	LNMASK = 0xFFFF;/*Solid line style*/
+	WMODE = mode; 	/*Writing mode*/
+	LSTLIN = 0;
+	linea3();
+}

--- a/raster.h
+++ b/raster.h
@@ -9,5 +9,5 @@ typedef unsigned int UINT16;
 void plot_bitmap_16(UINT16 *base, int x, int y, const UINT16 *bitmap, unsigned int height);
 void plot_bitmap_32(UINT32 *base, int x, int y, const UINT32 *bitmap, unsigned int height);
 void clear_screen(UINT16 *base, int pattern);
-
+void plot_hline(unsigned short y1, short mode);
 #endif


### PR DESCRIPTION
## What's Changed?:
- plot_hline() added
- makefile now can run "make clean"

## Usage:
- plot_hline() needs to have linea0() called first to initialize the library variables
- plot_hline(unsigned short y, short mode)