### PR TITLE
Minor formatting and logic fixes

### DIFF
--- a/TST_RAST.C
+++ b/TST_RAST.C
@@ -29,21 +29,21 @@ int main()
 	plot_borders_raster();
 	
 	/* DINOSAUR BITMAPS */
-	plot_bitmap_32((UINT32 *)base, 16, 184, dino_wdown_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 48, 184, dino_wup_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 80, 184, dino_dead_bitmap, HEIGHT_32, 1);
+	plot_bitmap_32((UINT32 *)base, 16, 184, dino_wdown_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 48, 184, dino_wup_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 80, 184, dino_dead_bitmap, HEIGHT_32);
 
 	/* NUMBER BITMAPS */
-	plot_bitmap_32((UINT32 *)base, 311, 359, zero_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 343, 359, one_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 375, 359, two_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 407, 359, three_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 439, 359, four_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 471, 359, five_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 503, 359, six_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 535, 359, seven_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 567, 359, eight_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 599, 359, nine_bitmap, HEIGHT_32, 1);
+	plot_bitmap_32((UINT32 *)base, 311, 359, zero_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 343, 359, one_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 375, 359, two_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 407, 359, three_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 439, 359, four_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 471, 359, five_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 503, 359, six_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 535, 359, seven_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 567, 359, eight_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 599, 359, nine_bitmap, HEIGHT_32);
 
 	/* OBSTACLE PLOTTING */
 	/*

--- a/dino_esc.c
+++ b/dino_esc.c
@@ -49,7 +49,7 @@ int main()
         {FALSE, FALSE, FALSE},                                  /* Context */
     };
     linea0();
-    /*disable_cursor();*/
+    /*disable_cursor(); Not needed here, already called in init_screen() */
 
      /* RENDER FIRST FRAME OF MODEL */
      init_screen(&new_game, (UINT16 *)base);

--- a/dino_esc.c
+++ b/dino_esc.c
@@ -24,24 +24,29 @@ int main()
     int i;
     /* INITIALIZE MODEL */
     void *base = Physbase();
-    unsigned int game_over = FALSE;
     UINT32 curr_time, prev_time, time_elapsed;
-    bool pt_scored = FALSE, dino_dead = FALSE;
+    bool game_over = FALSE, pt_scored = FALSE, dino_dead = FALSE;
     
     Model new_game = {
-        {{16, 184}, {47, 184}, {16, 215}, {47, 215}, {16, 184}, 0, 0, 0}, /* Dino variables */
+        {{16, 184}, {47, 184}, {16, 215}, {47, 215}, {16, 184}, 0, 0, 0}, /* Dino */
         {
-            {{{640, 50}, {671, 50}, {640, 200}, {671, 200}}, {{640, 251}, {671, 251}, {640, 351}, {671, 351}}, TRUE, FALSE, 200, OBS_START_SPEED},  /* wall 1 */
-            {{{640, 50}, {671, 50}, {640, 200}, {671, 200}}, {{640, 251}, {671, 251}, {640, 351}, {671, 351}}, FALSE, FALSE, 200, OBS_START_SPEED}, /* wall 2 */
-            {{{640, 50}, {671, 50}, {640, 200}, {671, 200}}, {{640, 251}, {671, 251}, {640, 351}, {671, 351}}, FALSE, FALSE, 200, OBS_START_SPEED}, /* wall 3 */
+            {{{640, 50}, {671, 50}, {640, 200}, {671, 200}},    /* Wall 1 - top */
+            {{640, 251}, {671, 251}, {640, 351}, {671, 351}},   /* Wall 1 - bottom */
+            TRUE, FALSE, 200, OBS_START_SPEED},
+            {{{640, 50}, {671, 50}, {640, 200}, {671, 200}},    /* Wall 2 - top */
+            {{640, 251}, {671, 251}, {640, 351}, {671, 351}},   /* Wall 2 - bottom */
+            FALSE, FALSE, 200, OBS_START_SPEED},
+            {{{640, 50}, {671, 50}, {640, 200}, {671, 200}},    /* Wall 3 - top */
+            {{640, 251}, {671, 251}, {640, 351}, {671, 351}},   /* Wall 3 - bottom */
+            FALSE, FALSE, 200, OBS_START_SPEED},
         },
-        {{{{505, 359}, {536, 359}, {505, 390}, {536, 390}, 0},  /* ones digit */
-          {{537, 359}, {568, 359}, {537, 390}, {568, 390}, 0},  /* tens digit */
-          {{569, 359}, {600, 359}, {568, 390}, {600, 390}, 0},  /* hundreds digit */
-          {{601, 359}, {632, 359}, {601, 390}, {632, 390}, 0}}, /* thousands digit */
-         5000,                                                  /* max score value */
-         0},                                                    /* current score value */
-        {FALSE, FALSE, FALSE}, /* Context variables */
+        {{{{505, 359}, {536, 359}, {505, 390}, {536, 390}, 0},  /* Ones digit */
+          {{537, 359}, {568, 359}, {537, 390}, {568, 390}, 0},  /* Tens digit */
+          {{569, 359}, {600, 359}, {568, 390}, {600, 390}, 0},  /* Hundreds digit */
+          {{601, 359}, {632, 359}, {601, 390}, {632, 390}, 0}}, /* Thousands digit */
+         5000,                                                  /* Max score */
+         0},                                                    /* Current score */
+        {FALSE, FALSE, FALSE},                                  /* Context */
     };
     linea0();
     disable_cursor();

--- a/dino_esc.c
+++ b/dino_esc.c
@@ -49,7 +49,7 @@ int main()
         {FALSE, FALSE, FALSE},                                  /* Context */
     };
     linea0();
-    disable_cursor();
+    /*disable_cursor();*/
 
      /* RENDER FIRST FRAME OF MODEL */
      init_screen(&new_game, (UINT16 *)base);

--- a/raster.c
+++ b/raster.c
@@ -187,13 +187,6 @@ void clear_screen(UINT16 *base, int pattern)
 				- 1: or		(will plot a black line over all previous bits)
 				- 2: xor	
 				- 3: and
-
-				temp. trying something
-				(https://www.atari-wiki.com/index.php?title=Pl2_LINEA.DOC)
-				- 0: AND			(background AND line)
-				- 1: OR				(background OR line)
-				- 2: TRANSPARENT 	((color AND line) OR (background(not line)))
-				- 3: XOR			(background XOR drawing)
 	OUTPUT: N/A
 ******************************************************************************/
 void plot_hline(unsigned short y, short mode)

--- a/raster.c
+++ b/raster.c
@@ -15,8 +15,8 @@
 #include <linea.h>
 #include <osbind.h>
 
-#define XOR 2
-#define HALF_GAP 25
+/*#define XOR 2
+#define HALF_GAP 25*/
 
 
 /*******************************************************************************
@@ -180,7 +180,7 @@ void clear_screen(UINT16 *base, int pattern)
 }
 
 /******************************************************************************
-	PURPOSE: To plot a horizontal line at a specified y coordinate
+	PURPOSE: Plots a horizontal line at the given y coordinate
 	INPUT: 	- y the y coordinate to plot the line at
 			- mode the behaviour of the line:
 				- 0: replace
@@ -195,8 +195,8 @@ void plot_hline(unsigned short y, short mode)
 	Y1 = y;
 	X2 = (unsigned short) 640;
 	Y2 = y;
-	LNMASK = 0xFFFF;/*Solid line style*/
-	WMODE = mode; 	/*Writing mode*/
+	LNMASK = 0xFFFF;	/* Solid line style */
+	WMODE = mode; 		/* Writing mode */
 	LSTLIN = 0;
 	linea3();
 }

--- a/raster.c
+++ b/raster.c
@@ -249,8 +249,7 @@ void plot_gline(unsigned short x1, unsigned short y1,
 }
 
 /*******************************************************************************
-	PURPOSE: 	To plot the upper and lower borders of the game, excluding the 
-				ground and roof triangles (rocks)
+	PURPOSE: Plots the upper and lower borders of the game
 	INPUT: 	N/A
 	OUTPUT: N/A
 *******************************************************************************/
@@ -258,14 +257,13 @@ void plot_borders()
 {
 	int i;
 
-	/* plots the upper and lower border lines with plot_hline()*/
+	/* plots the upper and lower border lines with plot_hline() */
 	for (i = 0; i < 50; i++){
 		plot_hline(i, XOR);
 		plot_hline(399 - i, XOR);
 	}
 
-	/*  plots lines to cancel out lines covering the score. will be implemented
-		in scoring function later in development*/
+	/*  plots lines to cancel out lines covering the score */
 	for (i = 390; i > 358; i--){
 		plot_gline(505, i, 631, i, XOR);
 	}

--- a/raster.c
+++ b/raster.c
@@ -30,7 +30,7 @@
 	OUTPUT: N/A
 *******************************************************************************/
 
-void plot_bitmap_32(UINT32 *base, int x, int y, const UINT32 *bitmap, unsigned int height, int mode) {
+void plot_bitmap_32(UINT32 *base, int x, int y, const UINT32 *bitmap, unsigned int height) {
     int i;
     int word_offset = (x >> 5) + (y * 20); /* Word-aligned base offset */
     int bit_shift = x & 31; /* Offset within the 32-bit word */
@@ -308,10 +308,10 @@ void plot_top_start_button(UINT32 *base, const UINT32 *lt_top_start_bitmap,
 	const UINT32 *mid_lt_top_start_bitmap, const UINT32 *mid_rt_top_start_bitmap,
 	const UINT32 *rt_top_start_bitmap)
 {
-	plot_bitmap_32((UINT32 *)base, 256, 168, lt_top_start_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 288, 168, mid_lt_top_start_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 320, 168, mid_rt_top_start_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 352, 168, rt_top_start_bitmap, HEIGHT_32, 1);
+	plot_bitmap_32((UINT32 *)base, 256, 168, lt_top_start_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 288, 168, mid_lt_top_start_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 320, 168, mid_rt_top_start_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 352, 168, rt_top_start_bitmap, HEIGHT_32);
 }
 
 /*******************************************************************************
@@ -328,10 +328,10 @@ void plot_bottom_start_button(UINT32 *base, const UINT32 *lt_bottom_start_bitmap
 	const UINT32 *mid_lt_bottom_start_bitmap, const UINT32 *mid_rt_bottom_start_bitmap,
 	const UINT32 *rt_bottom_start_bitmap)
 {
-	plot_bitmap_32((UINT32 *)base, 256, 200, lt_bottom_start_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 288, 200, mid_lt_bottom_start_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 320, 200, mid_rt_bottom_start_bitmap, HEIGHT_32, 1);
-	plot_bitmap_32((UINT32 *)base, 352, 200, rt_bottom_start_bitmap, HEIGHT_32, 1);
+	plot_bitmap_32((UINT32 *)base, 256, 200, lt_bottom_start_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 288, 200, mid_lt_bottom_start_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 320, 200, mid_rt_bottom_start_bitmap, HEIGHT_32);
+	plot_bitmap_32((UINT32 *)base, 352, 200, rt_bottom_start_bitmap, HEIGHT_32);
 }
 
 /*******************************************************************************
@@ -357,7 +357,7 @@ void disable_cursor()
 void plot_top_obs(UINT32 *base, int x, int gap_y, int mode)
 {
 	int edge_y = gap_y - HALF_GAP; 
-    plot_bitmap_32(base, x, edge_y - HEIGHT_32, obs_bottom_edge_bitmap, HEIGHT_32, mode);
+    plot_bitmap_32(base, x, edge_y - HEIGHT_32, obs_bottom_edge_bitmap, HEIGHT_32);
 
 }
 
@@ -373,7 +373,7 @@ void plot_top_obs(UINT32 *base, int x, int gap_y, int mode)
 void plot_bottom_obs(UINT32 *base, int x, int gap_y, int mode)
 {
 	int edge_y = gap_y + HALF_GAP; 
-    plot_bitmap_32(base, x, edge_y, obs_top_edge_bitmap, HEIGHT_32, mode);
+    plot_bitmap_32(base, x, edge_y, obs_top_edge_bitmap, HEIGHT_32);
 }
 
 /*******************************************************************************

--- a/raster.c
+++ b/raster.c
@@ -191,10 +191,14 @@ void clear_screen(UINT16 *base, int pattern)
 ******************************************************************************/
 void plot_hline(unsigned short y, short mode)
 {
+	/* Sets line start point coordinates */
 	X1 = (unsigned short) L_BORDER_X;
 	Y1 = y;
+	
+	/* Sets line end point coordinates */
 	X2 = (unsigned short) R_BORDER_X;
 	Y2 = y;
+	
 	LNMASK = 0xFFFF;	/* Solid line style */
 	WMODE = mode; 		/* Writing mode */
 	LSTLIN = 0;

--- a/raster.c
+++ b/raster.c
@@ -258,19 +258,19 @@ void plot_borders()
 	int i;
 
 	/* plots the upper and lower border lines with plot_hline() */
-	for (i = 0; i < 50; i++){
+	for (i = 0; i < 50; i++) {
 		plot_hline(i, XOR);
 		plot_hline(399 - i, XOR);
 	}
 
 	/*  plots lines to cancel out lines covering the score */
-	for (i = 390; i > 358; i--){
+	for (i = 390; i > 358; i--) {
 		plot_gline(505, i, 631, i, XOR);
 	}
 }
 
 /*******************************************************************************
-	PURPOSE: 	To plot the upper and lower borders of the game, excluding the 
+	PURPOSE: Plots the upper and lower borders of the game, excluding the 
 				ground and roof triangles (rocks). FOR PHASE 2 ONLY.
 	INPUT: 	N/A
 	OUTPUT: N/A
@@ -279,15 +279,14 @@ void plot_borders_raster()
 {
 	int i;
 
-	/* plots the upper and lower border lines with plot_hline()*/
-	for (i = 0; i < 50; i++){
+	/* plots the upper and lower border lines with plot_hline() */
+	for (i = 0; i < 50; i++) {
 		plot_hline(i, XOR);
 		plot_hline(399 - i, XOR);
 	}
 
-	/*  plots lines to cancel out lines covering the score. will be implemented
-		in scoring function later in development*/
-	for (i = 390; i > 358; i--){
+	/*  plots lines to cancel out lines covering the score */
+	for (i = 390; i > 358; i--) {
 		plot_gline(312, i, 631, i, XOR);
 	}
 }

--- a/raster.c
+++ b/raster.c
@@ -184,9 +184,16 @@ void clear_screen(UINT16 *base, int pattern)
 	INPUT: 	- y the y coordinate to plot the line at
 			- mode the behaviour of the line:
 				- 0: replace
-				- 1: or
-				- 2: xor
+				- 1: or		(will plot a black line over all previous bits)
+				- 2: xor	
 				- 3: and
+
+				temp. trying something
+				(https://www.atari-wiki.com/index.php?title=Pl2_LINEA.DOC)
+				- 0: AND			(background AND line)
+				- 1: OR				(background OR line)
+				- 2: TRANSPARENT 	((color AND line) OR (background(not line)))
+				- 3: XOR			(background XOR drawing)
 	OUTPUT: N/A
 ******************************************************************************/
 void plot_hline(unsigned short y, short mode)
@@ -199,9 +206,15 @@ void plot_hline(unsigned short y, short mode)
 	X2 = (unsigned short) R_BORDER_X;
 	Y2 = y;
 
-	LNMASK = 0xFFFF;	/* Solid line style */
+	/* Sets colour to black (linea document) */
+	COLBIT0 = 1;
+    COLBIT1 = 1;
+    COLBIT2 = 1;
+    COLBIT3 = 1;
+	
+	LNMASK = 0xFFFF;	/* Solid line style (pattern) */
 	WMODE = mode; 		/* Writing mode */
-	LSTLIN = 0;
+	LSTLIN = -1; 		/* changed from 0 to -1 as per linea document*/
 	linea3();
 }
 
@@ -263,14 +276,14 @@ void plot_borders()
 
 	/* plots the upper and lower border lines with plot_hline() */
 	for (i = 0; i < 50; i++) {
-		plot_hline(i, XOR);			/* upper border */
-		plot_hline(399 - i, XOR);	/* lower border */
+		plot_hline(i, OR);			/* upper border */
+		plot_hline(399 - i, OR);	/* lower border*/
 	}
 
 	/*  plots lines to cancel out lines covering the score */
-	for (i = 390; i > 358; i--) {
+	/*for (i = 390; i > 358; i--) {
 		plot_gline(505, i, 631, i, XOR);
-	}
+	}*/
 }
 
 /*******************************************************************************

--- a/raster.c
+++ b/raster.c
@@ -191,9 +191,9 @@ void clear_screen(UINT16 *base, int pattern)
 ******************************************************************************/
 void plot_hline(unsigned short y, short mode)
 {
-	X1 = (unsigned short) 0;
+	X1 = (unsigned short) L_BORDER_X;
 	Y1 = y;
-	X2 = (unsigned short) 640;
+	X2 = (unsigned short) R_BORDER_X;
 	Y2 = y;
 	LNMASK = 0xFFFF;	/* Solid line style */
 	WMODE = mode; 		/* Writing mode */

--- a/raster.c
+++ b/raster.c
@@ -198,7 +198,7 @@ void plot_hline(unsigned short y, short mode)
 	/* Sets line end point coordinates */
 	X2 = (unsigned short) R_BORDER_X;
 	Y2 = y;
-	
+
 	LNMASK = 0xFFFF;	/* Solid line style */
 	WMODE = mode; 		/* Writing mode */
 	LSTLIN = 0;
@@ -263,8 +263,8 @@ void plot_borders()
 
 	/* plots the upper and lower border lines with plot_hline() */
 	for (i = 0; i < 50; i++) {
-		plot_hline(i, XOR);
-		plot_hline(399 - i, XOR);
+		plot_hline(i, XOR);			/* upper border */
+		plot_hline(399 - i, XOR);	/* lower border */
 	}
 
 	/*  plots lines to cancel out lines covering the score */

--- a/raster.c
+++ b/raster.c
@@ -280,7 +280,7 @@ void plot_borders()
 		plot_hline(399 - i, OR);	/* lower border*/
 	}
 
-	/*  plots lines to cancel out lines covering the score */
+	/* NO LONGER NEEDED plots lines to cancel out lines covering the score */
 	/*for (i = 390; i > 358; i--) {
 		plot_gline(505, i, 631, i, XOR);
 	}*/

--- a/raster.h
+++ b/raster.h
@@ -7,6 +7,7 @@
 
 typedef unsigned long UINT32;
 typedef unsigned int UINT16;
+
 void plot_bitmap_32(UINT32 *base, int x, int y, const UINT32 *bitmap, unsigned int height);
 void clear_rect(UINT16 *base, int x, int y, int width, int height);
 void clear_square_32(UINT32 *base, int x, int y, int colour, int sqr_length);
@@ -23,7 +24,7 @@ void plot_top_obs(UINT32 *base, int x, int gap_y, int mode);
 void plot_bottom_obs(UINT32 *base, int x, int gap_y, int mode);
 void plot_obstacles(UINT32 *base, int x, int gap_y, int mode);          
 void plot_borders();
-void plot_borders_raster();
+void plot_borders_raster(); /* only used for stage 2 */
 void plot_top_start_button(UINT32 *base, const UINT32 *lt_top_start_bitmap,
 	        const UINT32 *mid_lt_top_start_bitmap, const UINT32 *mid_rt_top_start_bitmap,
 	        const UINT32 *rt_top_start_bitmap);

--- a/raster.h
+++ b/raster.h
@@ -4,6 +4,8 @@
 #define BYTES_PER_SCREEN 32000
 #define HEIGHT_32 32
 #define HEIGHT_16 16
+#define XOR 2
+#define HALF_GAP 25
 
 typedef unsigned long UINT32;
 typedef unsigned int UINT16;

--- a/raster.h
+++ b/raster.h
@@ -7,12 +7,12 @@
 
 typedef unsigned long UINT32;
 typedef unsigned int UINT16;
+void plot_bitmap_32(UINT32 *base, int x, int y, const UINT32 *bitmap, unsigned int height);
 void clear_rect(UINT16 *base, int x, int y, int width, int height);
 void clear_square_32(UINT32 *base, int x, int y, int colour, int sqr_length);
 void overwrite_bitmap_32(UINT32 *base, int x, int y, const UINT32 *bitmap, int height);
 void plot_bitmap_16(UINT16 *base, int x, int y, 
         const UINT16 *bitmap, unsigned int height);
-void plot_bitmap_32(UINT32 *base, int x, int y, const UINT32 *bitmap, unsigned int height, int mode);
 void clear_screen(UINT16 *base, int pattern);
 void plot_hline(unsigned short y, short mode);
 void plot_vline(unsigned short x, short mode);

--- a/raster.h
+++ b/raster.h
@@ -4,6 +4,7 @@
 #define BYTES_PER_SCREEN 32000
 #define HEIGHT_32 32
 #define HEIGHT_16 16
+#define OR 1
 #define XOR 2
 #define HALF_GAP 25
 

--- a/render.c
+++ b/render.c
@@ -59,7 +59,7 @@ void render_objs(const Model *new_game, UINT32 *base, bool pnt_earned, bool dino
     }
     else
     {
-        render_obs(new_game, base); /*will dissapear borders if called twice without updating border position */
+        render_obs(new_game, base);
         render_dino(new_game, base);
         if (pnt_earned)
         {

--- a/render.c
+++ b/render.c
@@ -19,6 +19,28 @@
 #include <linea.h>
 
 /*******************************************************************************
+    PURPOSE: Calls the functions to set up for the
+    start of the game, render the basic screen, score and borders
+    INPUT:  - base: 16 bit base address of the screen
+    OUTPUT: - N/A
+*******************************************************************************/
+void init_screen(const Model *game, UINT16 *base)
+{
+    int i;
+
+    Digit *digits = game->score.digits;
+
+    disable_cursor();
+    clear_screen((UINT16 *)base, 0);
+    plot_borders();
+
+    for (i = 0; i < 4; i++)
+    {
+        plot_bitmap_32((UINT32 *)base, digits[i].top_left.x, digits[i].top_left.y, zero_bitmap, HEIGHT_32, 1);
+    }
+}
+
+/*******************************************************************************
     PURPOSE: Calls the functions to render the obstacles in the game,
              the dino,
     INPUT:	- model: Game model
@@ -42,28 +64,6 @@ void render_objs(const Model *new_game, UINT32 *base, bool pnt_earned, bool dino
         {
             render_score(new_game, (UINT32 *)base);
         }
-    }
-}
-
-/*******************************************************************************
-    PURPOSE: Calls the functions to set up for the
-    start of the game, render the basic screen, score and borders
-    INPUT:  - base: 16 bit base address of the screen
-    OUTPUT: - N/A
-*******************************************************************************/
-void init_screen(const Model *game, UINT16 *base)
-{
-    int i;
-
-    Digit *digits = game->score.digits;
-
-    disable_cursor();
-    clear_screen((UINT16 *)base, 0);
-    plot_borders();
-
-    for (i = 0; i < 4; i++)
-    {
-        plot_bitmap_32((UINT32 *)base, digits[i].top_left.x, digits[i].top_left.y, zero_bitmap, HEIGHT_32, 1);
     }
 }
 

--- a/render.c
+++ b/render.c
@@ -19,8 +19,8 @@
 #include <linea.h>
 
 /*******************************************************************************
-    PURPOSE: Calls the functions to set up for the
-    start of the game, render the basic screen, score and borders
+    PURPOSE: Calls the functions to set up for the start of the game, render the
+                basic screen, score and borders
     INPUT:  - base: 16 bit base address of the screen
     OUTPUT: - N/A
 *******************************************************************************/
@@ -34,6 +34,7 @@ void init_screen(const Model *game, UINT16 *base)
     clear_screen((UINT16 *)base, 0);
     plot_borders();
 
+    /* Plots the initial score '0000' */
     for (i = 0; i < 4; i++)
     {
         plot_bitmap_32((UINT32 *)base, digits[i].top_left.x, digits[i].top_left.y, zero_bitmap, HEIGHT_32, 1);
@@ -41,8 +42,8 @@ void init_screen(const Model *game, UINT16 *base)
 }
 
 /*******************************************************************************
-    PURPOSE: Calls the functions to render the obstacles in the game,
-             the dino,
+    PURPOSE: Calls the functions to render the dino, the obstacles, and the
+                score in the game 
     INPUT:	- model: Game model
             - base: Base address of the screen
     OUTPUT: - N/A

--- a/render.c
+++ b/render.c
@@ -37,6 +37,7 @@ void init_screen(const Model *game, UINT16 *base)
     /* Plots the initial score '0000' */
     for (i = 0; i < 4; i++)
     {
+        clear_region((UINT32 *)base, digits[i].top_left.x, digits[i].top_left.y, 0x00000000);   /* clears spot in border for score */
         plot_bitmap_32((UINT32 *)base, digits[i].top_left.x, digits[i].top_left.y, zero_bitmap, HEIGHT_32);
     }
 }

--- a/render.c
+++ b/render.c
@@ -13,6 +13,7 @@
 #include "raster.h"
 #include "tst_mod.h"
 #include "bitmaps.h"
+#include "clock.h"
 #include <stdio.h>
 #include <osbind.h>
 #include <linea.h>

--- a/render.c
+++ b/render.c
@@ -37,7 +37,7 @@ void init_screen(const Model *game, UINT16 *base)
     /* Plots the initial score '0000' */
     for (i = 0; i < 4; i++)
     {
-        plot_bitmap_32((UINT32 *)base, digits[i].top_left.x, digits[i].top_left.y, zero_bitmap, HEIGHT_32, 1);
+        plot_bitmap_32((UINT32 *)base, digits[i].top_left.x, digits[i].top_left.y, zero_bitmap, HEIGHT_32);
     }
 }
 
@@ -95,7 +95,7 @@ void render_dino(const Model *game, UINT32 *base)
     }
     /* Draw new Dino frame */
     clear_region(base, dino->prev_top_lt.x, dino->prev_top_lt.y, 0x00000000);       /* clears previous dino bitmap */
-    plot_bitmap_32(base, dino->top_left.x, dino->top_left.y, bitmap, HEIGHT_32, 1); /* 1 = draw mode */
+    plot_bitmap_32(base, dino->top_left.x, dino->top_left.y, bitmap, HEIGHT_32); /* 1 = draw mode */
     /* Increment frame counter */
 }
 
@@ -111,7 +111,7 @@ void render_dino_dead(const Model *game, UINT32 *base)
     Dino *dino = &(game->dino);
     bitmap = dino_dead_bitmap;
     clear_region(base, dino->prev_top_lt.x, dino->prev_top_lt.y, 0x00000000);
-    plot_bitmap_32(base, dino->top_left.x, dino->top_left.y, bitmap, HEIGHT_32, 1);
+    plot_bitmap_32(base, dino->top_left.x, dino->top_left.y, bitmap, HEIGHT_32);
 }
 
 /*******************************************************************************
@@ -136,7 +136,7 @@ void render_score(const Model *model, UINT32 *base)
 
         /*clear_square_32((UINT32 *)base, digits[i].top_left.x, digits[i].top_left.y, 1, HEIGHT_32); /* clears previous bitmap */
         clear_region(base, digits[i].top_left.x, digits[i].top_left.y, 0x00000000); /* clears previous digit bitmap */
-        plot_bitmap_32((UINT32 *)base, digits[i].top_left.x, digits[i].top_left.y, digit_bitmaps[dig_index], HEIGHT_32, 1);
+        plot_bitmap_32((UINT32 *)base, digits[i].top_left.x, digits[i].top_left.y, digit_bitmaps[dig_index], HEIGHT_32);
     }
 }
 
@@ -187,7 +187,7 @@ void render_obs(const Model *model, UINT32 *base)
             plot_gline((top->top_right.x) + h_vel, T_BORDER_Y + 1, (top->top_right.x) + h_vel, (top->bot_right.y) - 31, XOR);          /*        ||    ||     ||  ->||    */
 
             clear_region(base, top->bot_left.x + vel, (top->bot_left.y) - 31, 0x00000000);
-            plot_bitmap_32(base, top->bot_left.x, (top->bot_left.y) - 31, obs_bottom_edge_bitmap, HEIGHT_32, 1);
+            plot_bitmap_32(base, top->bot_left.x, (top->bot_left.y) - 31, obs_bottom_edge_bitmap, HEIGHT_32);
 
             /*Plot new lines - BOTTOM */
             plot_gline(bottom->top_left.x, (bottom->top_left.y) + 31, bottom->top_left.x, B_BORDER_Y - 2, XOR);
@@ -201,7 +201,7 @@ void render_obs(const Model *model, UINT32 *base)
             plot_gline((bottom->top_right.x) + h_vel, (bottom->top_right.y) + 31, (bottom->top_right.x) + h_vel, B_BORDER_Y - 2, XOR);
 
             clear_region(base, bottom->top_left.x + vel, bottom->top_left.y, 0x00000000);
-            plot_bitmap_32(base, bottom->top_left.x, bottom->top_left.y, obs_top_edge_bitmap, HEIGHT_32, 1);
+            plot_bitmap_32(base, bottom->top_left.x, bottom->top_left.y, obs_top_edge_bitmap, HEIGHT_32);
 
             if (top->top_right.x == R_BORDER_X - 2 || top->top_right.x == R_BORDER_X - 1)
             {
@@ -237,20 +237,20 @@ void render_obs_2(const Model *model, UINT32 *base)
             for (k = (T_BORDER_Y + 1); k < (top->bot_left.y - 40); k += 16)
             {
                 clear_region(base, bottom->top_left.x + 2, k, 0x00000000);
-                plot_bitmap_32(base, bottom->top_left.x, k, obs_bitmap, HEIGHT_32, 1);
+                plot_bitmap_32(base, bottom->top_left.x, k, obs_bitmap, HEIGHT_32);
             }
 
             clear_region(base, top->bot_left.x + 2, (top->bot_left.y) - 31, 0x00000000);
-            plot_bitmap_32(base, top->bot_left.x, (top->bot_left.y) - 31, obs_bottom_edge_bitmap, HEIGHT_32, 1);
+            plot_bitmap_32(base, top->bot_left.x, (top->bot_left.y) - 31, obs_bottom_edge_bitmap, HEIGHT_32);
 
             for (k = (B_BORDER_Y - 1); k > (bottom->top_left.y + 32); k -= 16)
             {
                 clear_region(base, bottom->top_left.x + 2, k, 0x00000000);
-                plot_bitmap_32(base, bottom->top_left.x, k, obs_bitmap, HEIGHT_32, 1);
+                plot_bitmap_32(base, bottom->top_left.x, k, obs_bitmap, HEIGHT_32);
             }
 
             clear_region(base, bottom->top_left.x + 2, bottom->top_left.y, 0x00000000);
-            plot_bitmap_32(base, bottom->top_left.x, bottom->top_left.y, obs_top_edge_bitmap, HEIGHT_32, 1);
+            plot_bitmap_32(base, bottom->top_left.x, bottom->top_left.y, obs_top_edge_bitmap, HEIGHT_32);
         }
     }
 }

--- a/render.h
+++ b/render.h
@@ -8,8 +8,8 @@
 #include "bitmaps.h"
 
 
-void render_objs(const Model *model , UINT32 *base, bool pnt_earned, bool dino_dead);
 void init_screen(const Model *game, UINT16 *base);
+void render_objs(const Model *model , UINT32 *base, bool pnt_earned, bool dino_dead);
 void render_dino(const Model *game, UINT32 *base);
 void render_score(const Model *model , UINT32 *base);
 void render_start(const Model *model , UINT32 *base);


### PR DESCRIPTION
- Formatting edits to improve readability (no change to code functions)
- removed disable_cursor(); in dino_esc.c as it's already being called within init_screen()
- removed mode field from plot_bitmap_32() in raster.c and raster.h as it was no longer 	being used for anything within the method
- removed mode variable in all instances where plot_bitmap_32() is called, files affected: 	raster.c, render.c, and TST_RAST.C
- moved #define XOR 2 and #define HALF_GAP in raster.c to raster.h with the other defined 	constants for the raster files
- replaced '0' (line 194) and '640' (line 196) with constants L_BORDER_X and R_BORDER_X
- added constant definition #define OR 1 to raster.h
- edited plot_hline() in raster.c to include colbit0-4 so OR mode will work properly
- replaced XOR with OR (lines 279 and 280) in plot_borders() in raster.c
- added clear_region call to init_screen (line 40) in render.c for score plotting
-  removed the for loop in plot_borders() in raster.c used to cancel the score lines as its 	no longer required