### PR TITLE
Anna2

### DIFF
--- a/dino_esc.c
+++ b/dino_esc.c
@@ -40,13 +40,13 @@ int main()
         {{32, 184}, {63, 184}, {32, 215}, {63, 215}, {32, 184}, 0, 0, 0}, /* Dino */
         {
             {{{640, 50}, {671, 50}, {640, 200}, {671, 200}},    /* Wall 1 - top */
-            {{640, 249 /*250*/}, {671, 249 /*250*/}, {640, 349 /*350*/}, {671, 349 /*350*/}},   /* Wall 1 - bottom */
+            {{640, 249}, {671, 249}, {640, 349}, {671, 349}},   /* Wall 1 - bottom */
             TRUE, FALSE, 200, OBS_START_SPEED},
             {{{640, 50}, {671, 50}, {640, 200}, {671, 200}},    /* Wall 2 - top */
-            {{640, 249 /*250*/}, {671, 249 /*250*/}, {640, 349 /*350*/}, {671, 349 /*350*/}},   /* Wall 2 - bottom */
+            {{640, 249}, {671, 249}, {640, 349}, {671, 349}},   /* Wall 2 - bottom */
             FALSE, FALSE, 200, OBS_START_SPEED},
             {{{640, 50}, {671, 50}, {640, 200}, {671, 200}},    /* Wall 3 - top */
-            {{640, 249 /*250*/}, {671, 249 /*250*/}, {640, 349 /*350*/}, {671, 349 /*350*/}},   /* Wall 3 - bottom */
+            {{640, 249}, {671, 249}, {640, 349}, {671, 349}},   /* Wall 3 - bottom */
             FALSE, FALSE, 200, OBS_START_SPEED},
         },
         {{{{505, 359}, {536, 359}, {505, 390}, {536, 390}, 0},  /* Ones digit */
@@ -79,18 +79,12 @@ int main()
 
      /* RUN GAME UNTIL GAME OVER*/ 
     while (game_over == FALSE) {
-        /* CHECKS FOR PENDING INPUT */ 
-        /*read_input(&new_game);*/
-        if (new_game.game_state.dead_flag && x != TRUE){
-            render_objs(&new_game, (UINT32 *)back2_buffer);
-            render_objs(&new_game, (UINT32 *)back1_buffer);
-            x = TRUE;
-        }
+        /* CHECKS FOR PENDING INPUT */
         if (Cconis()) {
             key = (char)Cnecin();
-            /*while (Cconis()) {
+            while (Cconis()) {
                 Cnecin();
-            }*/
+            }
         }
 
         /* CHECKS FOR CLOCK TICK */
@@ -110,6 +104,7 @@ int main()
             render_objs(&new_game, (UINT32 *)back2_buffer);
             swap_buffer(&back1_buffer, &back2_buffer); 
             clear_cave_region((UINT32 *)back2_buffer);
+            
             /*clear_cave_region((UINT32 *)back2_buffer); */
             /*if (!new_game.game_state.dead_flag) {
                 move_walls(&new_game);
@@ -129,6 +124,13 @@ int main()
         }
          if (new_game.game_state.lost_flag == TRUE) {
              game_over = TRUE;
+        }
+
+        /* Syncs both buffers once collision has occured */
+        if (new_game.game_state.dead_flag && x != TRUE){
+            render_objs(&new_game, (UINT32 *)back2_buffer);
+            render_objs(&new_game, (UINT32 *)back1_buffer);
+            x = TRUE;
         }
     } 
     Setscreen(-1, base, -1);

--- a/dino_esc.c
+++ b/dino_esc.c
@@ -108,7 +108,7 @@ int main()
                 
             /* RENDER MODEL (NEXT FRAME) */ 
             render_objs(&new_game, (UINT32 *)back2_buffer);
-            swap_buffer(&back1_buffer, &back2_buffer); 
+            swap_buffer(&back1_buffer, &back2_buffer);
             clear_cave_region((UINT32 *)back2_buffer);
             
             /*clear_cave_region((UINT32 *)back2_buffer); */

--- a/dino_esc.c
+++ b/dino_esc.c
@@ -82,6 +82,7 @@ int main()
         /* CHECKS FOR PENDING INPUT */
         if (Cconis()) {
             key = (char)Cnecin();
+            /* Prevents build up of key presses on stack */
             while (Cconis()) {
                 Cnecin();
             }
@@ -92,13 +93,18 @@ int main()
         time_elapsed = curr_time - prev_time;
         if (time_elapsed > 0) {
             /* PROCESS SYNCHRONOUS EVENTS */
+
+            /* Moves dino */
             if (!new_game.game_state.dead_flag) {
-                process_input(&new_game, key);  /* Moves dino */
+                process_input(&new_game, key);
                 key = NULL;                     /* Resets input key */
             }
-
+            /* Moves walls */
             move_walls(&new_game);
+            /* Checks for collsion */
             check_collisions(&new_game);
+            /* Checks score */
+            check_score(&new_game);
                 
             /* RENDER MODEL (NEXT FRAME) */ 
             render_objs(&new_game, (UINT32 *)back2_buffer);

--- a/model.h
+++ b/model.h
@@ -6,7 +6,7 @@ typedef unsigned int bool;
 #define FALSE 0
 #define DEAD_VELOCITY 2
 #define HALF_GAP 25
-#define OBS_START_SPEED 2
+#define OBS_START_SPEED /*2*/ 4
 #define WIN_WIDTH 640
 #define WIN_HEIGHT 400
 #define T_BORDER_Y 49   /* 0 to 49 = 50 lines */

--- a/render.c
+++ b/render.c
@@ -53,8 +53,6 @@ void render_objs(const Model *new_game, UINT32 *base)
 {
     render_obs(new_game, base);
     render_dino(new_game, base);
-    
-    check_score(new_game);
     render_score(new_game, (UINT32 *)base);
     
 }

--- a/render.c
+++ b/render.c
@@ -53,8 +53,7 @@ void render_objs(const Model *new_game, UINT32 *base)
 {
     render_obs(new_game, base);
     render_dino(new_game, base);
-    render_score(new_game, (UINT32 *)base);
-    
+    render_score(new_game, (UINT32 *)base); 
 }
 
 /*******************************************************************************


### PR DESCRIPTION
- put back cconis while loop in dino_esc.c (lines 85-88) to prevent slight dino movement lag
- moved check_score() out of render_objs() in render.c (line 57) to the /* PROCESS
	SYNCHRONOUS EVENTS */ section of dino_esc.c (line 107)
- increased OBS_START_SPEED from 2 to 4 in model.h (line 9) **creates issue with dino
	clearing 1 pixel of obstacle when collision occurs on any obstacle other than the
	first one